### PR TITLE
fix: batch data ingestion was not working with separate docker containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,8 @@ services:
       start_period: 30s
     ports: 
       - ${HOST_API_PORT:-8080}:${API_PORT:-8080}
+    volumes:
+      - marble-tempfiles:/tempFiles
     environment:
       ENV: ${ENV:-development}
       PORT: ${API_PORT:-8080}
@@ -74,6 +76,8 @@ services:
     depends_on:
       - api
     entrypoint: ["./app", "--cron-scheduler"]
+    volumes:
+      - marble-tempfiles:/tempFiles
     environment:
       ENV: ${ENV:-development}
       PORT: ${API_PORT:-8080}
@@ -147,3 +151,4 @@ services:
 volumes:
   marble-db:
     driver: local
+  marble-tempfiles:


### PR DESCRIPTION
In the docker compose we run two separate containers for the api and cron job, while in local dev environment both are running on our machine.
However that breaks the batch ingestion feature, because the tempFiles folder (used for the ingestion files if no GCS bucket is attached, so mostly in demo mode) are not shared by the containers.
In this PR I add a volume to create such a shared volume.