### PR TITLE
Add notes about extra envvars to configure Docker Compose containers.

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,3 +1,9 @@
+# NOTE:
+# The variables set here are not all automatically passed to the containers when run with our provided
+# Docker Compose files. Only specific ones are (see docker-compose.yaml).
+# If you need to add new environment variables, refer to them in the Compose file in the appropriate
+# container for your configuration to be correctly applied.
+
 # Ports on the host Docker will listen on. Change them if they are clashing with other containers or processes that are running.
 HOST_API_PORT=8080
 HOST_APP_PORT=3000
@@ -32,7 +38,7 @@ METABASE_GLOBAL_DASHBOARD_ID=
 # Set up connection details to Convoy to enable webhooks sending.
 # You can get your project ID and API key from your project settings page in Convoy's dashboard, in the "Secrets" section.
 # NB: CONVOY_API_URL should be {scheme}://{host}:{port}/api - forgetting the /api will result in unexpected errors.
-CONVOY_API_URL= 
+CONVOY_API_URL=
 CONVOY_API_KEY=
 CONVOY_PROJECT_ID=
 

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+# NOTE:
+# The variables set here are not all automatically passed to the containers when run with our provided
+# Docker Compose files. Only specific ones are (see docker-compose.yaml).
+# If you need to add new environment variables, refer to them in the Compose file in the appropriate
+# container for your configuration to be correctly applied.
+
 #
 # REQUIRED SETTINGS
 #

--- a/installation/test_run.md
+++ b/installation/test_run.md
@@ -40,7 +40,9 @@ The development environment includes everything needed to run Marble locally:
 
 ### Basic Setup
 
-The `.env.dev.example` provides a minimal configuration that works out of the box:
+The `.env.dev.example` provides a minimal configuration that works out of the box.
+
+If you need to modify this configuration, note that the `.env` files are not inherited by the containers created by Docker Compose directly. Only select variables from the files are passed to the containers. If you need to add new variables (for example, if you want to configure file storage to point at your own S3 bucket), you will also need to edit the Docker Compose file to pass those variables to the appropriate container.
 
 ### Optional Features
 


### PR DESCRIPTION
Simple PR to add a note layout out how one could add extra environment variables to configure the Docker Compose test deployment.

We have had some issues with users trying to configure their AWS credentials in testing, where their variables would not be passed to the containers since they do not appear in the Compose file.