### PR TITLE
Update Yente to 4.3.1.

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -145,7 +145,7 @@ services:
       - marble-es:/usr/share/elasticsearch/data
   yente:
     container_name: marble-yente
-    image: ghcr.io/opensanctions/yente:4.2.1
+    image: ghcr.io/opensanctions/yente:4.3.1
     depends_on:
       - elasticsearch
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -157,7 +157,7 @@ services:
       - marble-es:/usr/share/elasticsearch/data
   yente:
     container_name: marble-yente
-    image: ghcr.io/opensanctions/yente:4.2.3
+    image: ghcr.io/opensanctions/yente:4.3.1
     depends_on:
       - elasticsearch
     command:
@@ -177,7 +177,7 @@ services:
       YENTE_AUTO_REINDEX: false
   yente-indexer:
     container_name: marble-yente-indexer
-    image: ghcr.io/opensanctions/yente:4.2.3
+    image: ghcr.io/opensanctions/yente:4.3.1
     depends_on:
       - elasticsearch
     command: ["yente", "reindex"]


### PR DESCRIPTION
This upgrades Yente to version 4.3.1.

**Note:** version 4.4.0 was just release, we might bump Yente again if we find no issues with it.