### PR TITLE
Fix frontend healthcheck to not use a shell.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -125,7 +125,12 @@ services:
     depends_on:
       - api
     healthcheck:
-      test: curl --fail http://localhost:${APP_PORT:-8080}/healthcheck || exit 1
+      test:
+        - CMD
+        - /nodejs/bin/node
+        - --input-type=module
+        - -e
+        - "process.exit((await fetch('http://localhost:${APP_PORT:-8080}/healthcheck')).status == 200 ? 0 : 1)"
       interval: 10s
       timeout: 60s
       retries: 1


### PR DESCRIPTION
The frontend healthcheck used to use a shell command to execute the request, but we are using a distroless image, which contains neither `sh`, or `curl`. This PR changes the way the healthcheck is done by both directly `execve`int the command and using Node to do it.